### PR TITLE
Fix - Add first and last name fields to signup

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -68,18 +68,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const register = async (
     email: string,
     password: string,
-    _passwordConfirmation: string
+    _passwordConfirmation: string,
+    first_name: string,
+    last_name: string
   ): Promise<void> => {
     setIsLoading(true);
     try {
-      await authApi.register({ email, password });
-
+      await authApi.register({ email, password, first_name, last_name });
       // NOTE: LOGIN WILL NOW HAPPEN AFTER EMAIL VERFICATION
-      // Manually perform login without calling the login function to avoid loading state conflicts
-      // const form = _form_helper(email, password);
-      // await authApi.login(form);
-
-      // await fetchMe();
     } catch (error) {
       setUser(null);
       throw error;

--- a/src/signup.tsx
+++ b/src/signup.tsx
@@ -12,6 +12,8 @@ import { useDispatch } from "react-redux";
 import { type AppDispatch } from "./lib/store";
 
 const signUpFormSchema = z.object({
+  first_name: z.string().min(1, "First name is required"),
+  last_name: z.string().min(1, "Last name is required"),
   email: z.string().email("Please enter a valid email address"),
   password: z.string().min(6, "Password must be at least 6 characters"),
   passwordConfirmation: z.string(),
@@ -32,19 +34,14 @@ export function SignUp() {
 
   async function onSubmit(values: z.infer<typeof signUpFormSchema>) {
     setError(null);
-
     try {
-      await register(values.email, values.password, values.passwordConfirmation);
-      // await dispatch(fetchTeams()).unwrap();
-      // const teams = await dispatch(fetchTeams()).unwrap();
-
-      // TODO: THIS WILL MIGRATE TO OTP PAGE
-      // If user has teams, navigate to dashboard, otherwise prompt user to
-      // create/join a team.
-      // teams.length === 0 ? navigate('/teams/join') : navigate('/dashboard');
-
-      // navigate(`/email-verify/${values.email}`);
-      // Passes 
+      await register(
+        values.email,
+        values.password,
+        values.passwordConfirmation,
+        values.first_name,
+        values.last_name
+      );
       navigate("/email-verify", {
         state: {
           email: values.email,
@@ -80,6 +77,30 @@ export function SignUp() {
             <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-3">
               <FormField
                 control={form.control}
+                name="first_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="John" type="text" {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="last_name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Doe" type="text" {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
                 name="email"
                 render={({ field }) => (
                   <FormItem>
@@ -90,7 +111,6 @@ export function SignUp() {
                   </FormItem>
                 )}
               />
-
               <FormField
                 control={form.control}
                 name="password"
@@ -103,13 +123,12 @@ export function SignUp() {
                   </FormItem>
                 )}
               />
-
               <FormField
                 control={form.control}
                 name="passwordConfirmation"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Password</FormLabel>
+                    <FormLabel>Confirm Password</FormLabel>
                     <FormControl>
                       <Input type="password" {...field} />
                     </FormControl>

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -11,7 +11,7 @@ export interface AuthContextType {
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
-  register: (email: string, password: string, passwordConfirm: string) => Promise<void>;
+  register: (email: string, password: string, passwordConfirm: string, name: string, lastname: string) => Promise<void>;
   verifyEmailAndLogin: (email: string, password: string, code: string) => Promise<void>;
 }
 
@@ -31,6 +31,9 @@ export interface AuthResponse {
 export interface RegisterPayload {
   email: string;
   password: string;
+  first_name: string;
+  last_name: string;
+  send_email?: boolean;
 }
 
 export interface LoginPayload {


### PR DESCRIPTION
This pull request enhances the user registration flow by adding support for first and last name fields during sign up. The changes ensure that both the frontend form and backend API payloads now handle these new fields, improving user data collection and validation.

**User Registration Flow Improvements**

* Added `first_name` and `last_name` fields to the registration form UI in `SignUp` component, including validation and input fields.
* Updated registration logic to pass `first_name` and `last_name` to the `register` function and subsequently to the backend API. 
**Type and Schema Updates**

* Extended the registration schema (`signUpFormSchema`) to require `first_name` and `last_name` fields, ensuring frontend validation.
* Updated the `AuthContextType` and `RegisterPayload` interfaces to include `first_name` and `last_name` fields for type safety and API compatibility. 

**Minor UI/UX Change**

* Changed label for password confirmation field to "Confirm Password" for clarity.